### PR TITLE
Support dag-json selector parsing

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -16,29 +16,54 @@ import (
 	// Dag-PB is additionally configured runtime
 	dagpb "github.com/ipld/go-codec-dagpb"
 	_ "github.com/ipld/go-ipld-prime/codec/raw"
+	"github.com/ipld/go-ipld-prime/datamodel"
+	"github.com/ipld/go-ipld-prime/traversal/selector"
 
 	"github.com/ipld/go-ipld-prime"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	basicnode "github.com/ipld/go-ipld-prime/node/basic"
 	"github.com/ipld/go-ipld-prime/traversal"
-	"github.com/ipld/go-ipld-prime/traversal/selector"
 
 	textselector "github.com/ipld/go-ipld-selector-text-lite"
 )
 
+const pathSelector = "Links/1/Hash/Links/001/Hash"
+const dagjsonSelector = `{"selector":{"f":{"f>":{"Links":{"f":{"f>":{"1":{"f":{"f>":{"Hash":{"f":{"f>":{"Links":{"f":{"f>":{"001":{"f":{"f>":{"Hash":{".":{}}}}}}}}}}}}}}}}}}}}}`
+
 func Example_selectorFromPath() {
-
-	//
-	// we put together a fixture datastore, and also return its root
-	ds, rootCid := fixtureDagService()
-
 	//
 	// Selector spec from a path, hopefully within that rootCid
 	// The 001 is deliberate: making sure index navigation still works
-	selectorSpec, err := textselector.SelectorSpecFromPath("Links/1/Hash/Links/001/Hash", false, nil)
+	selectorSpec, err := textselector.SelectorSpecFromPath(pathSelector, false, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	runSelector(selectorSpec.Node())
+
+	// Output:
+	// WantedNode
+}
+
+func Example_selectorFromDagjson() {
+	//
+	// Selector spec from a dag-json string, hopefully within that rootCid
+	// The spec should be the same as for the path version
+	selectorSpec, err := textselector.SelectorSpecFromJson(dagjsonSelector)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	runSelector(selectorSpec.Node())
+
+	// Output:
+	// WantedNode
+}
+
+func runSelector(selectorSpec datamodel.Node) {
+	//
+	// we put together a fixture datastore, and also return its root
+	ds, rootCid := fixtureDagService()
 
 	//
 	// this is how we R/O interact with the fixture DS
@@ -65,7 +90,7 @@ func Example_selectorFromPath() {
 
 	//
 	// compile our selector from spec
-	parsedSelector, err := selector.ParseSelector(selectorSpec.Node())
+	parsedSelector, err := selector.ParseSelector(selectorSpec)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -113,9 +138,6 @@ func Example_selectorFromPath() {
 	if err != nil {
 		log.Fatal(err)
 	}
-
-	// Output:
-	// WantedNode
 }
 
 func fixtureDagService() (mipld.DAGService, cid.Cid) {

--- a/parser.go
+++ b/parser.go
@@ -10,7 +10,10 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/ipld/go-ipld-prime/codec/dagjson"
+	"github.com/ipld/go-ipld-prime/datamodel"
 	basicnode "github.com/ipld/go-ipld-prime/node/basic"
+	"github.com/ipld/go-ipld-prime/traversal/selector"
 	"github.com/ipld/go-ipld-prime/traversal/selector/builder"
 )
 
@@ -76,4 +79,62 @@ func SelectorSpecFromPath(path Expression, matchPath bool, optionalSubselectorAt
 	}
 
 	return ss, nil
+}
+
+type selectorSpec struct {
+	n datamodel.Node
+	s selector.Selector
+}
+
+func (ss selectorSpec) Node() datamodel.Node {
+	return ss.n
+}
+
+func (ss selectorSpec) Selector() (selector.Selector, error) {
+	return ss.s, nil
+}
+
+/*
+SelectorSpecFromJson transforms a string form of a dag-json representation of a
+go-ipld-prime selector into a selector-spec object.
+
+The full dag-json form of a selector is not a user-friendly thing to construct,
+however it does allow for the representation of the full range of possible
+selectors where simple pathing-based selectors won't work.
+
+Note that using this format, the top-level of the input must be wrapped in an
+envelope (map) with a single field "selector".
+
+For example, a selector for the path x/y/10/z could be supplied to
+SelectorSpecFromJson as:
+
+	{"selector"{"f":{"f>":{"x":{"f":{"f>":{"y":{"f":{"f>":{"10":{"f":{"f>":{"z":{".":{}}}}}}}}}}}}}}}
+
+See https://ipld.io/specs/selectors/ for more information.
+*/
+func SelectorSpecFromJson(jsonStr string) (builder.SelectorSpec, error) {
+	// similar to selectorparse.ParseJSONSelector(input) but we want both the node
+	// and the selector, and we want to ensure a `"selector"` top-level field to
+	// contain the selector
+	nb := basicnode.Prototype.Any.NewBuilder()
+	if err := dagjson.Decode(nb, strings.NewReader(jsonStr)); err != nil {
+		return nil, err
+	}
+	n := nb.Build()
+	if n.Kind() != datamodel.Kind_Map {
+		return nil, fmt.Errorf("expected a map object from dag-json input")
+	}
+	if n.Length() != 1 {
+		return nil, fmt.Errorf("expected a single field map object from dag-json input")
+	}
+	n, err := n.LookupByString("selector")
+	if err != nil {
+		return nil, fmt.Errorf(`expected a "selector" field in dag-json input: %v`, err)
+	}
+	// will error if it's not a proper selector
+	sel, err := selector.CompileSelector(n)
+	if err != nil {
+		return nil, fmt.Errorf("dag-json input is not a valid selector: %v", err)
+	}
+	return selectorSpec{n, sel}, nil
 }


### PR DESCRIPTION
Riffing on https://github.com/filecoin-project/lotus/pull/6393, I'd like to be able to parse the full range of selectors and not just those we can represent with paths and not having to wait until we have finalised our text based form.

My thought here is that there could (should?) eventually be 3 ways to supply a selector on a command-line or via an API:

1. Simple path-based selector as per this library, that says (by default) "this is the path to the root of the full DAG I want"
2. Full selector optionality using dag-json to represent the `Selector` so you can supply whatever you like
3. Text-based simplified selector when we figure that out

So what I have here is really just a reimplementation of what you can do with traversal/selector/parse now, except that I've asserted the need to have a `{"selector":{...}}` envelope to be crystal clear that you're communicating a selector.

One reason I thought the envelope might be a good idea here is that it gets us toward a point where the overlap between these selector-as-text forms is zero. So an additional method we could add here is `SelectorSpecFromString()` that first tries to run `SelectorSpecFromJson()` on the string and then if that fails, run `SelectorSpecFromPath()`. So you could potentially make an API that says `--selector=...` where you can supply the path-based root selector or the full dag-json selector, or some future text-based simplified selector that we make sure doesn't conflict with either of these two (although the path based one may end up just being a subset of this).

The ambiguity may be a bit on the nose, however, so the alternative would be to `--selector` and a paired `--selector-format` to be explicit about what the user is supplying.

Re https://github.com/filecoin-project/lotus/pull/6393 I'm not (yet) suggesting this should be used there because it's only wanting to select a root and this gives flexibility to do more than that, but I am suggesting that maybe in the Lotus case we consider the possibility of extending input formats so (a) not tie the option name to "path" and (b) allow for a possible future second argument that lets you switch to alternative input forms.

Discuss.